### PR TITLE
Выполнить верстку экрана "Выбор страны"#33

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/feature/filter/presentation/fragments/ChooseCountryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/filter/presentation/fragments/ChooseCountryFragment.kt
@@ -1,0 +1,29 @@
+package ru.practicum.android.diploma.feature.filter.presentation.fragments
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import ru.practicum.android.diploma.databinding.FragmentChooseCountryBinding
+
+class ChooseCountryFragment : Fragment() {
+
+    private var _binding: FragmentChooseCountryBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Inflate the layout for this fragment
+        _binding = FragmentChooseCountryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+}

--- a/app/src/main/res/drawable/ic_arrow_forward.xml
+++ b/app/src/main/res/drawable/ic_arrow_forward.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="@color/blackDayWhiteNight" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6.23,20.23l1.77,1.77l10,-10l-10,-10l-1.77,1.77l8.23,8.23z"/>
+</vector>

--- a/app/src/main/res/layout/country_item.xml
+++ b/app/src/main/res/layout/country_item.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/country_item_textview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:padding="@dimen/dimens_16"
+        android:fontFamily="@font/ys_display_regular"
+        android:textSize="@dimen/textSize_16"
+        android:layout_marginHorizontal="@dimen/dimens_16"
+        android:textColor="@color/blackDayWhiteNight"
+        app:drawableRightCompat="@drawable/ic_arrow_forward"
+        tools:text="Россия"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/country_item.xml
+++ b/app/src/main/res/layout/country_item.xml
@@ -14,7 +14,6 @@
         android:padding="@dimen/dimens_16"
         android:fontFamily="@font/ys_display_regular"
         android:textSize="@dimen/textSize_16"
-        android:layout_marginHorizontal="@dimen/dimens_16"
         android:textColor="@color/blackDayWhiteNight"
         app:drawableRightCompat="@drawable/ic_arrow_forward"
         tools:text="Россия"/>

--- a/app/src/main/res/layout/fragment_choose_country.xml
+++ b/app/src/main/res/layout/fragment_choose_country.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".feature.filter.presentation.fragments.ChooseCountryFragment">
+
+    <ImageView
+        android:id="@+id/choose_country_back_arrow_imageview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dimens_20"
+        android:layout_marginTop="@dimen/dimens_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_back_arrow" />
+
+    <TextView
+        android:id="@+id/choose_workplace_header_textview"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dimens_20"
+        android:layout_marginTop="@dimen/dimens_20"
+        android:fontFamily="@font/ys_display_medium"
+        android:text="Выбор места работы"
+        android:textColor="@color/blackDayWhiteNight"
+        android:textSize="@dimen/textSize_22"
+        app:layout_constraintStart_toEndOf="@+id/choose_country_back_arrow_imageview"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/country_list_recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/dimens_48"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toBottomOf="@id/choose_country_back_arrow_imageview"
+        tools:listitem="@layout/country_item" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -19,9 +19,4 @@
         android:name="ru.practicum.android.diploma.feature.command.presentation.fragments.CommandFragment"
         android:label="fragment_command"
         tools:layout="@layout/fragment_command" />
-    <fragment
-        android:id="@+id/chooseCountryFragment"
-        android:name="ru.practicum.android.diploma.feature.filter.presentation.fragments.ChooseCountryFragment"
-        android:label="fragment_choose_country"
-        tools:layout="@layout/fragment_choose_country" />
 </navigation>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -19,4 +19,9 @@
         android:name="ru.practicum.android.diploma.feature.command.presentation.fragments.CommandFragment"
         android:label="fragment_command"
         tools:layout="@layout/fragment_command" />
+    <fragment
+        android:id="@+id/chooseCountryFragment"
+        android:name="ru.practicum.android.diploma.feature.filter.presentation.fragments.ChooseCountryFragment"
+        android:label="fragment_choose_country"
+        tools:layout="@layout/fragment_choose_country" />
 </navigation>


### PR DESCRIPTION
- Макет соответствует дизайну аналогичного шаблона в Figma (размеры, цвета, шрифты и т.д. должны совпадать)
- Макет выполнен как в светлой, так и темной темах
- Макет придерживается адаптивной верстки и выглядит репрезентативно на экранах с разным размером
- Создан соответствующий макету фрагмент и совмещен с макетом через атрибут tools:context