### PR TITLE
Task-branch-103: Передать вакансию с экрана "Избранные" на экран "Вакансия"

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/core/di/DetailsModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/core/di/DetailsModule.kt
@@ -12,6 +12,8 @@ import ru.practicum.android.diploma.feature.details.domain.usecases.ShareVacancy
 import ru.practicum.android.diploma.feature.details.presentation.viewmodels.VacancyViewModel
 import ru.practicum.android.diploma.feature.favourite.domain.usecase.AddVacancyToFavouriteUseCase
 import ru.practicum.android.diploma.feature.favourite.domain.usecase.RemoveVacancyFromFavouriteUseCase
+import ru.practicum.android.diploma.feature.favourite.domain.usecase.GetVacancyByIdUseCase
+
 
 val detailsModule = module {
     viewModelOf(::VacancyViewModel)
@@ -20,6 +22,7 @@ val detailsModule = module {
     singleOf(::SendEmailUseCase)
     singleOf(::AddVacancyToFavouriteUseCase)
     singleOf(::RemoveVacancyFromFavouriteUseCase)
+    singleOf(::GetVacancyByIdUseCase)
     singleOf(::ExternalNavigatorImpl) bind ExternalNavigator::class
 
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/details/presentation/viewmodels/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/details/presentation/viewmodels/VacancyViewModel.kt
@@ -16,6 +16,7 @@ import ru.practicum.android.diploma.feature.details.presentation.DataState
 import ru.practicum.android.diploma.feature.favourite.data.model.toVacancyFullEntity
 import ru.practicum.android.diploma.feature.favourite.domain.usecase.AddVacancyToFavouriteUseCase
 import ru.practicum.android.diploma.feature.favourite.domain.usecase.GetFavoriteIdsUseCase
+import ru.practicum.android.diploma.feature.favourite.domain.usecase.GetVacancyByIdUseCase
 import ru.practicum.android.diploma.feature.favourite.domain.usecase.RemoveVacancyFromFavouriteUseCase
 import ru.practicum.android.diploma.feature.search.domain.GetVacancyUseCase
 import ru.practicum.android.diploma.feature.search.domain.models.VacancyFull
@@ -27,7 +28,8 @@ class VacancyViewModel(
     private val getVacancyUseCase: GetVacancyUseCase,
     private val addVacancyToFavouriteUseCase: AddVacancyToFavouriteUseCase,
     private val removeVacancyFromFavouriteUseCase: RemoveVacancyFromFavouriteUseCase,
-    private val getFavoriteIdsUseCase: GetFavoriteIdsUseCase
+    private val getFavoriteIdsUseCase: GetFavoriteIdsUseCase,
+    private val getVacancyByIdUseCase: GetVacancyByIdUseCase,
 ) : ViewModel() {
 
     private var _dataState = MutableLiveData<DataState>()
@@ -101,5 +103,14 @@ class VacancyViewModel(
             val isFavorite = vacancyIds?.contains(vacancyId) == true
             _isFavorite.postValue(isFavorite)
         }
+    }
+
+    fun getVacancyById(vacancyId: String): LiveData<VacancyFull?> {
+        val vacancyLiveData = MutableLiveData<VacancyFull?>()
+        viewModelScope.launch(Dispatchers.IO) {
+            val vacancy = getVacancyByIdUseCase.getVacancyById(vacancyId)
+            vacancyLiveData.postValue(vacancy)
+        }
+        return vacancyLiveData
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/favourite/data/db/FavoriteVacancyDao.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/favourite/data/db/FavoriteVacancyDao.kt
@@ -21,4 +21,7 @@ interface FavoriteVacancyDao {
 
     @Query("SELECT id FROM vacancy_table")
     suspend fun getAllVacancyIds(): List<String>
+
+    @Query("SELECT * FROM vacancy_table WHERE id = :id")
+    suspend fun getVacancyById(id: String): VacancyFullEntity?
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/favourite/data/repository/FavoriteRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/favourite/data/repository/FavoriteRepositoryImpl.kt
@@ -30,4 +30,9 @@ class FavoriteRepositoryImpl(private val appDatabase: AppDatabase): FavoriteRepo
         val listId= appDatabase.getVacancyDao().getAllVacancyIds()
         emit(listId)
     }
+
+    override suspend fun getVacancyById(id: String): VacancyFull? {
+        val vacancyEntity = appDatabase.getVacancyDao().getVacancyById(id)
+        return vacancyEntity?.toVacancyFull()
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/favourite/domain/repository/FavoriteRepository.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/favourite/domain/repository/FavoriteRepository.kt
@@ -18,4 +18,6 @@ interface FavoriteRepository {
 
     fun getAllVacancyIds(): Flow<List<String>>
 
+    suspend fun getVacancyById(id: String): VacancyFull?
+
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/favourite/domain/usecase/GetVacancyByIdUseCase.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/favourite/domain/usecase/GetVacancyByIdUseCase.kt
@@ -1,0 +1,14 @@
+package ru.practicum.android.diploma.feature.favourite.domain.usecase
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.coroutineScope
+import ru.practicum.android.diploma.feature.favourite.domain.repository.FavoriteRepository
+import ru.practicum.android.diploma.feature.search.domain.models.VacancyFull
+
+class GetVacancyByIdUseCase(private val favoriteRepository: FavoriteRepository) {
+
+    suspend fun getVacancyById(vacancyId: String): VacancyFull? {
+         return  favoriteRepository.getVacancyById(vacancyId)
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/feature/favourite/presentation/fragments/FavouriteFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/favourite/presentation/fragments/FavouriteFragment.kt
@@ -6,9 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentFavouriteBinding
 import ru.practicum.android.diploma.feature.favourite.data.model.toVacancyFullEntity
 import ru.practicum.android.diploma.feature.favourite.data.model.toVacancyShort
@@ -67,7 +69,9 @@ class FavouriteFragment : Fragment(),SimilarVacanciesAdapter.ClickListener {
     }
 
     override fun onClick(vacancy: VacancyShort) {
-
+        val bundle = Bundle()
+        bundle.putString("vacancyId", vacancy.id)
+        findNavController().navigate(R.id.action_favouriteFragment_to_vacancyFragment, bundle)
     }
 
     override fun onResume() {

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -20,7 +20,11 @@
         android:id="@+id/favouriteFragment"
         android:name="ru.practicum.android.diploma.feature.favourite.presentation.fragments.FavouriteFragment"
         android:label="fragment_favourite"
-        tools:layout="@layout/fragment_favourite" />
+        tools:layout="@layout/fragment_favourite" >
+        <action
+            android:id="@+id/action_favouriteFragment_to_vacancyFragment"
+            app:destination="@id/vacancyFragment" />
+    </fragment>
     <fragment
         android:id="@+id/commandFragment"
         android:name="ru.practicum.android.diploma.feature.command.presentation.fragments.CommandFragment"


### PR DESCRIPTION
- Создан в data дао метод возвращающий вакансию по id
- Создан domain интерфейс возвращающий вакансию по id и его имплементацию
- Создан domain usecase возвращающий вакансию по id
- Добавлен метод получение вакансии по id во ViewModel вакансии
- Реализован метод передачи id вакансии из экрана "Избранные" через bundle
- Добавлена зависимость в модуль Koin detailsModule
- При отсутствие интернета скрыта кнопка похожие вакансии